### PR TITLE
refactor: STEP7 메모리 효율 향상

### DIFF
--- a/app/src/main/java/kr/co/prnd/mvvmeventsample/step7/Step7ViewModel.kt
+++ b/app/src/main/java/kr/co/prnd/mvvmeventsample/step7/Step7ViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @HiltViewModel
 class Step7ViewModel @Inject constructor() : ViewModel() {
 
-    private val _eventChannel = Channel<Event>(Channel.BUFFERED)
+    private val _eventChannel = Channel<Event>(Channel.CONFLATED)
     val eventFlow = _eventChannel.receiveAsFlow()
 
     fun showToast() = viewModelScope.launch {
@@ -38,5 +38,10 @@ class Step7ViewModel @Inject constructor() : ViewModel() {
         data class ShowToast(val text: String) : Event()
         data class Aaa(val value: String) : Event()
         data class Bbb(val value: Int) : Event()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        _eventChannel.close()
     }
 }


### PR DESCRIPTION
## 히스토리

아래 아티클을 읽어 봤습니다. 관련하여 궁금한 부분이 있어서 PR을 작성하게 되었습니다.
- [MVVM의 ViewModel에서 이벤트를 처리하는 방법 7가지](https://medium.com/prnd/mvvm%EC%9D%98-viewmodel%EC%97%90%EC%84%9C-%EC%9D%B4%EB%B2%A4%ED%8A%B8%EB%A5%BC-%EC%B2%98%EB%A6%AC%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95-6%EA%B0%80%EC%A7%80-31bb183a88ce)
- [ViewModel에서 더이상 EventFlow를 사용하지 마세요](https://medium.com/prnd/viewmodel%EC%97%90%EC%84%9C-%EB%8D%94%EC%9D%B4%EC%83%81-eventflow%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%A7%80-%EB%A7%88%EC%84%B8%EC%9A%94-3974e8ddffed)

## 의문점

Channel.BUFFERED 선택 이유
- Channel.RENDEZVOUS 사용 시 버퍼가 없어 구독자가 없을 때 중단되는 문제가 있음을 인지하였습니다.
- 하지만 버퍼 사이즈 64는 작다면 작지만 단일 이벤트 처리에 과도하다는 생각이 들었습니다.
- 버퍼 사이즈를 1로 해도 되지 않을까 싶었는데, 아티클의 STEP5을 보니 주기적으로 위치 데이터를 받는 것에도 사용되는 것으로 이해하였습니다. 따라서 이런 이벤트는 이전 데이터를 굳이 유지할 필요가 없을 것 같다는 생각이 듭니다.

## 변경점

-  STEP5의 경우를 고려하여 Channel.CONFLATED을 제안해 봅니다.
- repeatOnStarted + receiveAsFlow()로 인해 채널이 닫히지 않기 때문에 메모리 누수 방지를 위해서 ViewModel이 종료될 때 채널을 닫는 작업을 추가하면 좋을 것 같습니다.

## 참고

- 변경 히스토리와 내부 사정에 대해 자세히 모르기 때문에 저의 제안이 타당하지 않을 수 있습니다.